### PR TITLE
Make poster ids only thread-unique

### DIFF
--- a/imgboard.php
+++ b/imgboard.php
@@ -223,7 +223,7 @@ if (!isset($_GET['delete']) && !isset($_GET['manage']) && (
 	if ($rawPost || !in_array('password', $hideFields)) {
 		$post['password'] = $_POST['password'] != '' ? md5(md5($_POST['password'])) : '';
 	}
-	$post['nameblock'] = nameBlock($post['name'], $post['tripcode'], $post['email'], $post['ip'],
+	$post['nameblock'] = nameBlock($post['name'], $post['tripcode'], $post['email'], $post['ip'], $post['parent'],
 		time(), $rawPostText);
 
 	// Embed URL uploaded

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -326,11 +326,11 @@ function nameAndTripcode($name) {
 	return array($name, "");
 }
 
-function nameBlock($name, $tripcode, $email, $ip, $timestamp, $rawposttext) {
+function nameBlock($name, $tripcode, $email, $ip, $parent, $timestamp, $rawposttext) {
 	list($loggedIn, $isAdmin) = manageCheckLogIn();
 	$posterUID = '';
 	if (TINYIB_POSTERUID) {
-		$hash = substr(md5($ip . TINYIB_TRIPSEED), 0, 8);
+		$hash = substr(md5($ip . intval($parent) . TINYIB_TRIPSEED), 0, 8);
 		$hashint = hexdec('0x' . $hash);
 		$red = $hashint >> 24 & 255;
 		$green = $hashint >> 16 & 255;


### PR DESCRIPTION
Note the ids are consistent in the thread, but different across threads
<img width="488" alt="image" src="https://github.com/SthephanShinkufag/atomboard/assets/1666014/fa046b28-c1c9-45cc-9bc3-43a7dcebcf6c">
<img width="545" alt="image" src="https://github.com/SthephanShinkufag/atomboard/assets/1666014/3f3dbe07-2b7f-4359-b840-728e639e814c">

(ID of the OP is always going to be different since there is no way to know the thread ID during thread creation)