### PR TITLE
Block dirty ips

### DIFF
--- a/imgboard.php
+++ b/imgboard.php
@@ -608,6 +608,9 @@ function postingRequest() {
 			unset($_SESSION['atom_captcha']);
 		}
 
+		// Check for dirty ip (using external service)
+		lookupDirtyIp($_SERVER['REMOTE_ADDR']);
+
 		// Check for ban
 		$ban = banByIP($_SERVER['REMOTE_ADDR']);
 		if ($ban) {

--- a/inc/database_mysql.php
+++ b/inc/database_mysql.php
@@ -37,6 +37,11 @@ if (mysql_num_rows(mysql_query("SHOW TABLES LIKE '" . ATOM_DBMODLOG . "'")) == 0
 	mysql_query($modlogQuery);
 }
 
+// Create the ip lookups table if it does not exist
+if (mysql_num_rows(mysql_query("SHOW TABLES LIKE '" . ATOM_DBIPLOOKUPS . "'")) == 0) {
+	mysql_query($ipLookupsQuery);
+}
+
 /* ==[ Posts ]============================================================================================= */
 
 function insertPost($post) {
@@ -383,6 +388,35 @@ function bumpThread($id) {
 		"UPDATE `" . ATOM_DBPOSTS . "`
 		SET `bumped` = " . time() . "
 		WHERE `id` = " . $id . " LIMIT 1");
+}
+
+/* ==[ Dirty IP lookups ]===================================================================================== */
+
+function lookupByIP($ip) {
+	$result = mysql_query(
+		"SELECT * FROM " . ATOM_DBIPLOOKUPS . "
+		WHERE ip = '" .  mysql_real_escape_string($ip) . "' LIMIT 1",
+		array($ip));
+	if ($result) {
+		while ($ban = mysql_fetch_assoc($result)) {
+			return $ban;
+		}
+	}
+}
+
+function storeLookupResult($ip, $abuser, $vps, $proxy, $tor, $vpn) {
+    mysql_query(
+		"INSERT INTO `" . ATOM_DBIPLOOKUPS . "`
+		(ip, abuser, vps, proxy, tor, vpn)
+		VALUES (
+			'" . mysql_real_escape_string($ip) . "',
+			'" . mysql_real_escape_string($abuser) . "',
+			'" . mysql_real_escape_string($vps) . "',
+			'" . mysql_real_escape_string($proxy) . "',
+			'" . mysql_real_escape_string($tor) . "',
+			'" . mysql_real_escape_string($vpn) . "'
+		)");
+	return mysql_insert_id();
 }
 
 /* ==[ Bans ]============================================================================================== */

--- a/settings.default.php
+++ b/settings.default.php
@@ -54,6 +54,8 @@ define('ATOM_DBMODLOG', ATOM_BOARD . '_modlog');
 define('ATOM_DBBANS', 'bans');
 // Likes table name in database (use the same likes table across boards for global likes)
 define('ATOM_DBLIKES', 'likes');
+// Database for dirty ip lookups
+define('ATOM_DBIPLOOKUPS', 'iplookups');
 // Enable database migration tool (see README for instructions)
 define('ATOM_DBMIGRATE', false);
 
@@ -79,6 +81,20 @@ define('ATOM_DBDRIVER', 'mysql');
 // When changing this, you should still set ATOM_DBDRIVER appropriately
 // If you're using PDO with a MySQL or pgSQL database, you should leave this blank
 define('ATOM_DBDSN', '');
+
+/* ==[ Dirty Ip Lookups ]==================================================================================== */
+// Ip lookups, using ipregistry.co. Set ATOM_IPLOOKUPS_KEY to '' to disable, othwerise provide a key.
+define('ATOM_IPLOOKUPS_KEY', '');
+// Block abusive IPs
+define('ATOM_IPLOOKUPS_BLOCK_ABUSER', true);
+// Block IPs under cloud providers
+define('ATOM_IPLOOKUPS_BLOCK_VPS', true);
+// Block IPs under proxy
+define('ATOM_IPLOOKUPS_BLOCK_PROXY', true);
+// Block IPs under TOR network
+define('ATOM_IPLOOKUPS_BLOCK_TOR', true);
+// Block IPs under VPN
+define('ATOM_IPLOOKUPS_BLOCK_VPN', true);
 
 /* ==[ Posts ]============================================================================================= */
 // Default poster names


### PR DESCRIPTION
The change add a configurable check to block abusive IPs thru service ipregistry.co

- It works like follows: when a post is made, the poster's IP is verified thru external service.
- Results are checked against 5 categories: Abuser, Vps, Proxy, Tor, and Vpn.
- Depending on the atom configuration, ether category can be blocked.
- Results are cached into local database, so only each unique post request consumes a ip lookup. Services provides 100000 lookups for free, so we should be good for like ever.