### PR TITLE
Separate max files size for passcode users

### DIFF
--- a/imgboard.php
+++ b/imgboard.php
@@ -1123,10 +1123,18 @@ function postingRequest() {
 
 			// Check for upload errors
 			$fileIdxTxt = 'File №' . $fileIdx;
+
+			if (ATOM_PASSCODES_ENABLED) {
+				$f_sz_error_text = $fileIdxTxt . ' is larger than ' . ATOM_FILE_MAXKBDESC . ' (' .
+					ATOM_FILE_MAXKBDESC_PASS . ' for passcode users).';
+			} else {
+				$f_sz_error_text = $fileIdxTxt . ' is larger than ' . ATOM_FILE_MAXKBDESC . '.';
+			}
+
 			switch ($error) {
 			case UPLOAD_ERR_OK: break;
 			case UPLOAD_ERR_FORM_SIZE:
-				fancyDie($fileIdxTxt . ' is larger than ' . ATOM_FILE_MAXKBDESC . '.');
+                fancyDie($f_sz_error_text);
 				break;
 			case UPLOAD_ERR_INI_SIZE:
 				fancyDie($fileIdxTxt . ' exceeds the upload_max_filesize directive (' .
@@ -1146,9 +1154,15 @@ function postingRequest() {
 				fancyDie($fileIdxTxt . ' transfer failure.<br>Please retry the submission.');
 			}
 
-			// Check for bytes size restriction
-			if (ATOM_FILE_MAXKB > 0 && filesize($file) > ATOM_FILE_MAXKB * 1024) {
-				fancyDie($fileIdxTxt . ' is larger than ' . ATOM_FILE_MAXKBDESC . '.');
+			// Check for bytes size restriction (but it only applies to passcode users)
+			if (ATOM_PASSCODES_ENABLED && $validPasscode) {
+				if (ATOM_FILE_MAXKB_PASS > 0 && filesize($file) > ATOM_FILE_MAXKB_PASS * 1024) {
+					fancyDie($f_sz_error_text);
+				}
+			} else {
+				if (ATOM_FILE_MAXKB > 0 && filesize($file) > ATOM_FILE_MAXKB * 1024) {
+					fancyDie($f_sz_error_text);
+				}
 			}
 
 			// Get post image fields

--- a/inc/html.php
+++ b/inc/html.php
@@ -173,10 +173,17 @@ function buildPostForm($parent, $isStaffPost = false) {
 	$embedInputHtml = '';
 	if (!empty($atom_uploads) && ($isStaffPost || !in_array('file', $hideFields))) {
 		if (ATOM_FILE_MAXKB > 0) {
+		    $extra = '';
+		    $max_fs = ATOM_FILE_MAXKB;
+		    if (ATOM_PASSCODES_ENABLED) {
+		        $max_fs = max($max_fs, ATOM_FILE_MAXKB_PASS);
+		        $extra = ' (' . ATOM_FILE_MAXKBDESC_PASS . ' for <a href="/' . ATOM_BOARD .
+		            '/imgboard.php?passcode">Passcode users</a> users)';
+		    }
 			$maxFileSizeInputHtml = '<input type="hidden" name="MAX_FILE_SIZE" value="' .
-				strval(ATOM_FILE_MAXKB * 1024) . '">';
+				strval($max_fs * 1024) . '">';
 			$maxFileSizeRulesHtml = '<li>Limit: ' . ATOM_FILES_COUNT . ' ' .
-				plural('file', ATOM_FILES_COUNT) . ', ' . ATOM_FILE_MAXKBDESC . ' per file.</li>';
+				plural('file', ATOM_FILES_COUNT) . ', ' . ATOM_FILE_MAXKBDESC . ' per file' . $extra . '.</li>';
 		}
 		$fileTypesHtml = '<li>' . supportedFileTypes() . '</li>';
 		$fileInputHtml = '<tr>

--- a/settings.default.php
+++ b/settings.default.php
@@ -187,6 +187,10 @@ $atom_embeds = array(
 define('ATOM_FILE_MAXKB', 20480);
 // Human-readable representation of the maximum file size
 define('ATOM_FILE_MAXKBDESC', '20 MB');
+// Maximum file size in kilobytes for passcode users (if enabled), 0 to disable
+define('ATOM_FILE_MAXKB_PASS', 40960);
+// Human-readable representation of the maximum file size for passcode users (if enabled)
+define('ATOM_FILE_MAXKBDESC_PASS', '40 MB');
 // Maximum number of uploaded files (up to 4)
 define('ATOM_FILES_COUNT', 4);
 // Thumbnail method to use: 'gd', 'imagemagick' (see README for instructions)


### PR DESCRIPTION
New options:

`ATOM_FILE_MAXKB_PASS` - separate maximum file size limit for passcode users (has to be below php's `upload_max_filesize`)
`ATOM_FILE_MAXKBDESC_PASS` - description of it